### PR TITLE
fix: linked_actions.action is optional

### DIFF
--- a/src/api/v1/types.ts
+++ b/src/api/v1/types.ts
@@ -36,7 +36,7 @@ import {ABISerializableObject, ABISerializableType, Serializer} from '../../seri
 @Struct.type('account_linked_action')
 export class AccountLinkedAction extends Struct {
     @Struct.field('name') declare account: Name
-    @Struct.field('name') declare action: Name
+    @Struct.field('name', {optional: true}) declare action: Name
 }
 
 @Struct.type('account_permission')


### PR DESCRIPTION
If `eosio::linkauth()` is called with a wildcard/empty action name, then the action name is not returned by the API

see
![image](https://github.com/wharfkit/antelope/assets/25777536/7f25f555-8850-4122-947e-0f7f33e07e18)
