### PR TITLE
Caching ABI in Action for future use

### DIFF
--- a/src/chain/action.ts
+++ b/src/chain/action.ts
@@ -81,7 +81,16 @@ export class Action extends Struct {
         } else {
             const type = getType(data)
             if (type) {
-                action.abi = ABI.from(synthesizeABI(type).abi)
+                action.abi = ABI.from({
+                    ...synthesizeABI(type).abi,
+                    actions: [
+                        {
+                            name: String(action.name),
+                            type: String(action.name),
+                            ricardian_contract: '',
+                        },
+                    ],
+                })
             }
         }
 
@@ -116,6 +125,16 @@ export class Action extends Struct {
                 throw new Error(`Action ${this.name} does not exist in provided ABI`)
             }
             return abiDecode({data: this.data, type, abi})
+        }
+    }
+
+    get decoded() {
+        if (!this.abi) {
+            throw new Error('Missing ABI definition when decoding action data')
+        }
+        return {
+            ...this.toJSON(),
+            data: this.decodeData(this.abi),
         }
     }
 }

--- a/src/chain/action.ts
+++ b/src/chain/action.ts
@@ -58,7 +58,6 @@ export class Action extends Struct {
     public abi?: ABI
 
     static from(object: ActionType | AnyAction, abi?: ABIDef): Action {
-        // console.log(object)
         const data = object.data as any
         if (!Bytes.isBytes(data)) {
             let type: string | undefined
@@ -86,7 +85,7 @@ export class Action extends Struct {
                     actions: [
                         {
                             name: String(action.name),
-                            type: String(action.name),
+                            type: type.abiName,
                             ricardian_contract: '',
                         },
                     ],

--- a/src/chain/action.ts
+++ b/src/chain/action.ts
@@ -84,7 +84,7 @@ export class Action extends Struct {
                     ...synthesizeABI(type).abi,
                     actions: [
                         {
-                            name: String(action.name),
+                            name: action.name,
                             type: type.abiName,
                             ricardian_contract: '',
                         },

--- a/src/chain/transaction.ts
+++ b/src/chain/transaction.ts
@@ -119,7 +119,13 @@ export class Transaction extends TransactionHeader {
                 return abis
             }
         }
-        const resolveAction = (action: AnyAction) => Action.from(action, abiFor(action.account))
+        const resolveAction = (action: AnyAction) => {
+            if (action instanceof Action) {
+                return action
+            } else {
+                return Action.from(action, abiFor(action.account))
+            }
+        }
         const actions = (object.actions || []).map(resolveAction)
         const context_free_actions = (object.context_free_actions || []).map(resolveAction)
         const transaction = {

--- a/test/chain.ts
+++ b/test/chain.ts
@@ -1,6 +1,7 @@
 import {assert} from 'chai'
 
 import {
+    ABI,
     ABIDef,
     Action,
     AnyTransaction,
@@ -18,6 +19,7 @@ import {
     P2P,
     PermissionLevel,
     PublicKey,
+    Serializer,
     Signature,
     SignedTransaction,
     Struct,
@@ -481,6 +483,74 @@ suite('chain', function () {
         )
         assert.equal(a1.equals(a2), true)
         assert.equal(a1.equals(a3), true)
+    })
+
+    test('action retains abi (abi)', function () {
+        const abi = {
+            structs: [{name: 'noop', base: '', fields: []}],
+            actions: [
+                {
+                    name: 'noop',
+                    type: 'noop',
+                    ricardian_contract: '',
+                },
+            ],
+        }
+        const action = Action.from(
+            {
+                account: 'greymassnoop',
+                name: 'noop',
+                authorization: [{actor: 'greymassfuel', permission: 'cosign'}],
+                data: '',
+            },
+            abi
+        )
+        assert.instanceOf(action.abi, ABI)
+    })
+
+    test('action retains abi (struct)', function () {
+        @Struct.type('transfer')
+        class Transfer extends Struct {
+            @Struct.field('name') from!: Name
+            @Struct.field('name') to!: Name
+            @Struct.field('asset') quantity!: Asset
+            @Struct.field('string') memo!: string
+        }
+
+        const data = Transfer.from({
+            from: 'foo',
+            to: 'bar',
+            quantity: '1.0000 EOS',
+            memo: 'hello',
+        })
+
+        const action = Action.from({
+            authorization: [],
+            account: 'eosio.token',
+            name: 'transfer',
+            data,
+        })
+        assert.instanceOf(action.abi, ABI)
+
+        const transaction = Transaction.from({
+            ref_block_num: 0,
+            ref_block_prefix: 0,
+            expiration: 0,
+            actions: [action],
+        })
+
+        assert.instanceOf(transaction.actions[0].abi, ABI)
+        assert.isTrue(action.equals(transaction.actions[0]))
+        assert.isTrue(transaction.actions[0].equals(action))
+        assert.isTrue(
+            data.equals(
+                Serializer.decode({
+                    data: transaction.actions[0].data,
+                    abi: transaction.actions[0].abi,
+                    type: String(transaction.actions[0].name),
+                })
+            )
+        )
     })
 
     test('authority', function () {

--- a/test/chain.ts
+++ b/test/chain.ts
@@ -346,33 +346,33 @@ suite('chain', function () {
             data: variant,
         })
         assert.equal(action.equals(action), true)
-        assert.equal(
-            action.equals({
-                account: 'foo',
-                name: 'bar',
-                authorization: [perm],
-                data: variant,
-            }),
-            true
-        )
-        assert.equal(
-            action.equals({
-                account: 'foo',
-                name: 'bar',
-                authorization: [],
-                data: variant,
-            }),
-            false
-        )
-        assert.equal(
-            action.equals({
-                account: 'foo',
-                name: 'bar',
-                authorization: [{actor: 'maa', permission: 'jong'}],
-                data: variant,
-            }),
-            false
-        )
+        // assert.equal(
+        //     action.equals({
+        //         account: 'foo',
+        //         name: 'bar',
+        //         authorization: [perm],
+        //         data: variant,
+        //     }),
+        //     true
+        // )
+        // assert.equal(
+        //     action.equals({
+        //         account: 'foo',
+        //         name: 'bar',
+        //         authorization: [],
+        //         data: variant,
+        //     }),
+        //     false
+        // )
+        // assert.equal(
+        //     action.equals({
+        //         account: 'foo',
+        //         name: 'bar',
+        //         authorization: [{actor: 'maa', permission: 'jong'}],
+        //         data: variant,
+        //     }),
+        //     false
+        // )
 
         const time = TimePointSec.from(1)
         assert.equal(time.equals(time), true)

--- a/test/chain.ts
+++ b/test/chain.ts
@@ -339,40 +339,63 @@ suite('chain', function () {
         assert.equal(variant.equals(Int32.from(1)), false)
         assert.equal(variant.equals(MyVariant.from('haj')), false)
 
+        @Struct.type('my_struct')
+        class MyStructWithVariant extends Struct {
+            @Struct.field(MyVariant) field!: MyVariant
+        }
         const action = Action.from({
             account: 'foo',
             name: 'bar',
             authorization: [perm],
-            data: variant,
+            data: MyStructWithVariant.from({
+                field: variant,
+            }),
         })
         assert.equal(action.equals(action), true)
-        // assert.equal(
-        //     action.equals({
-        //         account: 'foo',
-        //         name: 'bar',
-        //         authorization: [perm],
-        //         data: variant,
-        //     }),
-        //     true
-        // )
-        // assert.equal(
-        //     action.equals({
-        //         account: 'foo',
-        //         name: 'bar',
-        //         authorization: [],
-        //         data: variant,
-        //     }),
-        //     false
-        // )
-        // assert.equal(
-        //     action.equals({
-        //         account: 'foo',
-        //         name: 'bar',
-        //         authorization: [{actor: 'maa', permission: 'jong'}],
-        //         data: variant,
-        //     }),
-        //     false
-        // )
+        assert.equal(
+            action.equals({
+                account: 'foo',
+                name: 'bar',
+                authorization: [perm],
+                data: {
+                    field: 'hello',
+                },
+            }),
+            true
+        )
+        assert.equal(
+            action.equals({
+                account: 'foo',
+                name: 'bar',
+                authorization: [perm],
+                data: {
+                    field: variant,
+                },
+            }),
+            true
+        )
+        assert.equal(
+            action.equals({
+                account: 'foo',
+                name: 'bar',
+                authorization: [],
+                data: {
+                    field: variant,
+                },
+            }),
+            false
+        )
+        assert.equal(
+            action.equals({
+                account: 'foo',
+                name: 'bar',
+                authorization: [{actor: 'maa', permission: 'jong'}],
+                data: {
+                    field: variant,
+                },
+            }),
+            false
+        )
 
         const time = TimePointSec.from(1)
         assert.equal(time.equals(time), true)


### PR DESCRIPTION
This is an idea to help the contract kit send transactions to the session kit...

The problem right now with the contract kit, when performing transactions, is you need to manually specify and pass in the ABIs to the `session.transact` call to prevent duplicate calls to retrieve the ABI.

The idea was that in situations where we have the ABI or a Struct, we can embed that into the `Action` class, which is what's passed into `session.transact`. If an ABI existed someplace like `action.abi`, then the Session Kit during the `transct` call would be able to do something like:

```
actions.forEach(action => {
  if (actions.abi) {
    // add ABI to ABI Cache
  }
})
```

Which would then prevent the session kit from needing to go out and fetch the ABI (since it's in the action already).

It's basically a trojan horse to pass along the `ABI` inside of the `Action`, for processes upstream that might be interacting with that `Action`. 

This is probably a bad implementation, but it works, and submitted this as a draft to express the idea.