### PR TITLE
Making get_accounts_by_authorizers match API pattern

### DIFF
--- a/src/api/v1/chain.ts
+++ b/src/api/v1/chain.ts
@@ -11,7 +11,6 @@ import {
     Name,
     NameType,
     PackedTransaction,
-    PublicKeyType,
     SignedTransaction,
     SignedTransactionType,
     UInt128,
@@ -24,6 +23,7 @@ import {
     AccountObject,
     AccountsByAuthorizers,
     GetAbiResponse,
+    GetAccountsByAuthorizersParams,
     GetBlockHeaderStateResponse,
     GetBlockResponse,
     GetInfoResponse,
@@ -75,10 +75,10 @@ export class ChainAPI {
         })
     }
 
-    async get_accounts_by_authorizers(keys: PublicKeyType[]) {
+    async get_accounts_by_authorizers(params: GetAccountsByAuthorizersParams) {
         return this.client.call({
             path: '/v1/chain/get_accounts_by_authorizers',
-            params: {keys: keys},
+            params,
             responseType: AccountsByAuthorizers,
         })
     }

--- a/src/api/v1/types.ts
+++ b/src/api/v1/types.ts
@@ -16,7 +16,9 @@ import {
     KeyWeight,
     Name,
     NameType,
+    PermissionLevel,
     PublicKey,
+    PublicKeyType,
     Signature,
     Struct,
     TimePoint,
@@ -173,7 +175,8 @@ export class AccountObject extends Struct {
 export class AccountByAuthorizersRow extends Struct {
     @Struct.field(Name) declare account_name: Name
     @Struct.field(Name) declare permission_name: Name
-    @Struct.field(PublicKey) declare authorizing_key: PublicKey
+    @Struct.field(PublicKey, {optional: true}) declare authorizing_key: PublicKey
+    @Struct.field(PermissionLevel, {optional: true}) declare authorizing_account: PermissionLevel
     @Struct.field(Weight) declare weight: Weight
     @Struct.field(UInt32) declare threshold: UInt32
 }
@@ -689,4 +692,9 @@ export interface GetProtocolFeaturesParams {
     search_by_block_num?: boolean
     /** Whether to iterate records in reverse order. */
     reverse?: boolean
+}
+
+export interface GetAccountsByAuthorizersParams {
+    accounts?: NameType[]
+    keys?: PublicKeyType[]
 }

--- a/test/api.ts
+++ b/test/api.ts
@@ -170,10 +170,10 @@ suite('api v1', function () {
         assert.isTrue(permission.linked_actions[0].action.equals('transfer'))
     })
 
-    test('chain get_accounts_by_authorizers', async function () {
-        const response = await jungle4.v1.chain.get_accounts_by_authorizers([
-            'PUB_K1_6RWZ1CmDL4B6LdixuertnzxcRuUDac3NQspJEvMnebGcXY4zZj',
-        ])
+    test('chain get_accounts_by_authorizers (keys)', async function () {
+        const response = await jungle4.v1.chain.get_accounts_by_authorizers({
+            keys: ['PUB_K1_6RWZ1CmDL4B6LdixuertnzxcRuUDac3NQspJEvMnebGcXY4zZj'],
+        })
         assert.lengthOf(response.accounts, 5)
         assert.isTrue(response.accounts[0].account_name.equals('testtestasdf'))
         assert.isTrue(response.accounts[0].permission_name.equals('owner'))
@@ -182,6 +182,19 @@ suite('api v1', function () {
                 'PUB_K1_6RWZ1CmDL4B6LdixuertnzxcRuUDac3NQspJEvMnebGcXY4zZj'
             )
         )
+        assert.isTrue(response.accounts[0].weight.equals(1))
+        assert.isTrue(response.accounts[0].threshold.equals(1))
+    })
+
+    test('chain get_accounts_by_authorizers (accounts)', async function () {
+        const response = await jungle4.v1.chain.get_accounts_by_authorizers({
+            accounts: ['eosio.prods'],
+        })
+        assert.lengthOf(response.accounts, 1)
+        assert.isTrue(response.accounts[0].account_name.equals('eosio'))
+        assert.isTrue(response.accounts[0].permission_name.equals('active'))
+        assert.isTrue(response.accounts[0].authorizing_account.actor.equals('eosio.prods'))
+        assert.isTrue(response.accounts[0].authorizing_account.permission.equals('active'))
         assert.isTrue(response.accounts[0].weight.equals(1))
         assert.isTrue(response.accounts[0].threshold.equals(1))
     })

--- a/test/data/4406a3af18dbfafd488dffdd79db994d8cc09706.json
+++ b/test/data/4406a3af18dbfafd488dffdd79db994d8cc09706.json
@@ -1,0 +1,28 @@
+{
+    "headers": {
+        "access-control-allow-headers": "Origin, X-Requested-With, Content-Type, Accept",
+        "access-control-allow-methods": "GET, POST, HEAD, OPTIONS",
+        "access-control-allow-origin": "*",
+        "connection": "close",
+        "content-length": "159",
+        "content-type": "application/json",
+        "date": "Mon, 14 Aug 2023 01:17:06 GMT",
+        "server": "nginx/1.24.0"
+    },
+    "status": 200,
+    "json": {
+        "accounts": [
+            {
+                "account_name": "eosio",
+                "permission_name": "active",
+                "authorizing_account": {
+                    "actor": "eosio.prods",
+                    "permission": "active"
+                },
+                "weight": 1,
+                "threshold": 1
+            }
+        ]
+    },
+    "text": "{\"accounts\":[{\"account_name\":\"eosio\",\"permission_name\":\"active\",\"authorizing_account\":{\"actor\":\"eosio.prods\",\"permission\":\"active\"},\"weight\":1,\"threshold\":1}]}"
+}


### PR DESCRIPTION
The way the API was originally written didn't allow querying against this API by the `accounts` parameter. 

This PR changes the method call to use `{keys: [], accounts: []}` like the API natively accepts.

This is a breaking change, so we'll need to bump to 0.8 or 1.0.