### PR TITLE
Accepting that nodeos returns NaN for floats

### DIFF
--- a/src/chain/float.ts
+++ b/src/chain/float.ts
@@ -46,6 +46,10 @@ class Float implements ABISerializableObject {
     value: number
 
     constructor(value: number) {
+        if (Number.isNaN(value)) {
+            this.value = 0
+            return
+        }
         if (!Number.isFinite(value)) {
             throw new Error('Invalid number')
         }

--- a/src/chain/float.ts
+++ b/src/chain/float.ts
@@ -46,13 +46,6 @@ class Float implements ABISerializableObject {
     value: number
 
     constructor(value: number) {
-        if (Number.isNaN(value)) {
-            this.value = 0
-            return
-        }
-        if (!Number.isFinite(value)) {
-            throw new Error('Invalid number')
-        }
         this.value = value
     }
 


### PR DESCRIPTION
This is related to: https://github.com/wharfkit/contract/issues/50

The contract and APIs can apparently return `-nan` as a value here as a `Float`. This adds a check that detects this weirdness, and if found, just sets the value to the float as 0 and proceeds.

I'm open to ideas on how better to resolve this. We just need to accept that the APIs will not return valid data here that matches the ABI for some reason.