### PR TITLE
Stop the mutation of the `object` parameter

### DIFF
--- a/src/chain/action.ts
+++ b/src/chain/action.ts
@@ -54,7 +54,8 @@ export class Action extends Struct {
     /** The ABI-encoded action data. */
     @Struct.field('bytes') data!: Bytes
 
-    static from(object: ActionType | AnyAction, abi?: ABIDef): Action {
+    static from(anyAction: ActionType | AnyAction, abi?: ABIDef): Action {
+        let object = {...anyAction}
         const data = object.data as any
         if (!Bytes.isBytes(data)) {
             let type: string | undefined


### PR DESCRIPTION
I just ran into a situation while working on the Session Kit unit tests, where I was reusing the same `Action` over and over again in multiple tests, and while using the resulting `Action` in the serializer I started getting this error:

```ts
Error: assertion failure with message: datastream attempted to read past the end
```

When running individual tests in isolation... the bug wouldn't occur, it'd only occur when I was running bulk unit tests that utilized the same `Action`. So I started debugging and noticed this instance of parameter mutation on `Action.from()`. By simply tweaking this to not mutate the function parameter, the error message above no longer occurs. 