### PR TITLE
Add extended_symbol type

### DIFF
--- a/src/chain/asset.ts
+++ b/src/chain/asset.ts
@@ -290,6 +290,46 @@ export class ExtendedAsset implements ABISerializableObject {
     }
 }
 
+export type ExtendedSymbolType = ExtendedSymbol | {sym: Asset.SymbolType; contract: NameType}
+export class ExtendedSymbol implements ABISerializableObject {
+    static abiName = 'extended_symbol'
+
+    static from(value: ExtendedSymbolType) {
+        if (isInstanceOf(value, ExtendedSymbol)) {
+            return value
+        }
+        return new this(Asset.Symbol.from(value.sym), Name.from(value.contract))
+    }
+
+    static fromABI(decoder: ABIDecoder) {
+        return new ExtendedSymbol(Asset.Symbol.fromABI(decoder), Name.fromABI(decoder))
+    }
+
+    sym: Asset.Symbol
+    contract: Name
+
+    constructor(sym: Asset.Symbol, contract: Name) {
+        this.sym = sym
+        this.contract = contract
+    }
+
+    equals(other: ExtendedSymbolType) {
+        return this.sym.equals(other.sym) && this.contract.equals(other.contract)
+    }
+
+    toABI(encoder: ABIEncoder) {
+        this.sym.toABI(encoder)
+        this.contract.toABI(encoder)
+    }
+
+    toJSON() {
+        return {
+            sym: this.sym,
+            contract: this.contract,
+        }
+    }
+}
+
 function toSymbolPrecision(rawSymbol: UInt64) {
     return rawSymbol.value.and(UInt64.from(0xff).value).toNumber()
 }

--- a/src/serializer/builtins.ts
+++ b/src/serializer/builtins.ts
@@ -10,6 +10,7 @@ import {
     Checksum256,
     Checksum512,
     ExtendedAsset,
+    ExtendedSymbol,
     Float128,
     Float32,
     Float64,
@@ -74,6 +75,10 @@ export interface BuiltinTypes {
     'extended_asset?'?: ExtendedAsset
     'extended_asset[]': ExtendedAsset[]
     'extended_asset[]?'?: ExtendedAsset[]
+    extended_symbol: ExtendedSymbol
+    'extended_symbol?'?: ExtendedSymbol
+    'extended_symbol[]': ExtendedSymbol[]
+    'extended_symbol[]?'?: ExtendedSymbol[]
     bytes: Bytes
     'bytes?'?: Bytes
     'bytes[]': Bytes[]
@@ -199,6 +204,7 @@ function getBuiltins(): ABISerializableConstructor[] {
         Checksum256,
         Checksum512,
         ExtendedAsset,
+        ExtendedSymbol,
         Float128,
         Float32,
         Float64,

--- a/test/serializer.ts
+++ b/test/serializer.ts
@@ -818,6 +818,10 @@ suite('serializer', function () {
                 quantity: '3.1415926 PI',
                 contract: 'pi.token',
             },
+            extended_symbol: {
+                sym: '7,PI',
+                contract: 'pi.token',
+            },
             alias1: true,
             alias2: true,
             alias3: {
@@ -846,7 +850,8 @@ suite('serializer', function () {
                 'ffffffffff000223e0ae8aacb41b06dc74af1a56b2eb69133f07f7f75bd1d5e53316bff195edf400205150a67288c3b393' +
                 'fdba9061b05019c54b12bdac295fc83bebad7cd63c7bb67d5cb8cc220564da006240a58419f64d06a5c6e1fc62889816a6' +
                 'c3dfdd231ed38907504900000000005049000000000000765edf01000000000750490000000000765edf01000000000750' +
-                '49000000000000000053419a81ab0101010001020101000568656c6c6f0105776f726c6400'
+                '49000000000000000053419a81ab075049000000000000000053419a81ab0101010001020101000568656c6c6f0105776f' +
+                '726c6400'
         )
         const decoded = Serializer.decode({data, type: 'all_types', abi})
         assert.deepStrictEqual(JSON.parse(JSON.stringify(decoded)), object)

--- a/test/typestresser.abi.json
+++ b/test/typestresser.abi.json
@@ -54,6 +54,7 @@
                 {"name": "symbol_code", "type": "symbol_code"},
                 {"name": "asset", "type": "asset"},
                 {"name": "extended_asset", "type": "extended_asset"},
+                {"name": "extended_symbol", "type": "extended_symbol"},
                 {"name": "alias1", "type": "alias1"},
                 {"name": "alias2", "type": "alias2"},
                 {"name": "alias3", "type": "alias3"},


### PR DESCRIPTION
This PR adds the `extended_symbol` type

Simply copied from `ExtendedAsset` and made neccessary changes.