### PR TITLE
Adding codingPath to serializer errors

### DIFF
--- a/src/serializer/decoder.ts
+++ b/src/serializer/decoder.ts
@@ -245,7 +245,11 @@ function decodeObject(value: any, type: ABI.ResolvedType, ctx: DecodingContext):
                 return null
             }
         }
-        throw new Error(`Unexpectedly encountered ${value} for non-optional`)
+        throw new Error(
+            `Unexpectedly encountered ${value} for non-optional (${ctx.codingPath
+                .map((path) => path.field)
+                .join('.')})`
+        )
     } else if (type.isArray) {
         if (!Array.isArray(value)) {
             throw new Error('Expected array')

--- a/src/serializer/encoder.ts
+++ b/src/serializer/encoder.ts
@@ -179,7 +179,11 @@ export function encodeAny(value: any, type: ABI.ResolvedType, ctx: EncodingConte
             if (type.isExtension) {
                 return
             }
-            throw new Error(`Found ${value} for non-optional type: ${type.typeName}`)
+            throw new Error(
+                `Found ${value} for non-optional type: ${type.typeName} (${ctx.codingPath
+                    .map((path) => path.field)
+                    .join('.')})`
+            )
         }
         if (abiType && abiType.toABI) {
             // type explicitly handles encoding


### PR DESCRIPTION
Creates a nicer error message, like:

![telegram-cloud-photo-size-1-5131947987407318118-y](https://github.com/wharfkit/antelope/assets/677686/e125eb66-54a5-4994-958e-48da58d6d851)
