### PR TITLE
Support symbol of value 0

### DIFF
--- a/src/chain/asset.ts
+++ b/src/chain/asset.ts
@@ -126,8 +126,11 @@ export namespace Asset {
                 return new Symbol(value)
             }
             const parts = value.split(',')
-            if (parts.length !== 2) {
+            if (parts.length !== 2 && value !== '0,') {
                 throw new Error('Invalid symbol string')
+            }
+            if (value === '0,') {
+                parts.push("")
             }
             const precision = Number.parseInt(parts[0])
             return Symbol.fromParts(parts[1], precision)

--- a/src/chain/asset.ts
+++ b/src/chain/asset.ts
@@ -155,7 +155,7 @@ export namespace Asset {
             if (toSymbolPrecision(value) > Symbol.maxPrecision) {
                 throw new Error('Invalid asset symbol, precision too large')
             }
-            if (!SymbolCode.pattern.test(toSymbolName(value))) {
+            if (value !== UInt64.from(0) && !SymbolCode.pattern.test(toSymbolName(value))) {
                 throw new Error('Invalid asset symbol, name must be uppercase A-Z')
             }
             this.value = value
@@ -232,7 +232,7 @@ export namespace Asset {
         value: UInt64
 
         constructor(value: UInt64) {
-            if (!SymbolCode.pattern.test(toSymbolName(value))) {
+            if (value !== UInt64.from(0) && !SymbolCode.pattern.test(toSymbolName(value))) {
                 throw new Error('Invalid asset symbol, name must be uppercase A-Z')
             }
             this.value = value

--- a/test/chain.ts
+++ b/test/chain.ts
@@ -55,6 +55,12 @@ suite('chain', function () {
         assert.equal(symbol.precision, '10')
         assert.equal(Asset.Symbol.from(symbol.value).toString(), symbol.toString())
 
+        const nft_symbol = Asset.Symbol.from(Asset.Symbol.from('0,'))
+        assert.equal(nft_symbol.name, '')
+        assert.equal(nft_symbol.precision, '0')
+        assert.equal(Asset.Symbol.from(nft_symbol.value).toString(), nft_symbol.toString())
+        assert.equal(nft_symbol.value, 0)
+
         // test null asset
         asset = Asset.from('0 ')
         assert.equal(Number(asset.value), 0)


### PR DESCRIPTION
The current implementation of Wharfkit doesn't support the _valid_ EOSIO `symbol` of zero value. While the EOSIO `asset` type (unfortunately) doesn't support this symbol value the EOSIO `symbol` type indeed does. Symbols of value zero are useful to encode NFT assets according to the [AtomicAssets](https://github.com/pinknetworkx/atomicassets-contract) standard.

This PR adds support for symbols of zero value encoded by the symbol string `"0,"`.