### PR TITLE
Add isAllZero check to prevent invalid private keys in PrivateKey

### DIFF
--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -196,4 +196,32 @@ suite('crypto', function () {
             PrivateKey.fromString(String(k))
         })
     })
+
+    test('invalid private key (zero key)', function () {
+        const zeroBytes = new Uint8Array(32) // all zero
+        // PVT_K1_111111111111111111111111111111112omJse
+        let keyStr = 'PVT_K1_' + Base58.encodeRipemd160Check(zeroBytes, 'K1')
+        try {
+            PrivateKey.from(keyStr)
+            assert.fail()
+        } catch (error) {
+            assert.ok(error instanceof Error, 'Error should be an instance of Error')
+            assert.ok(
+                error.message.includes('All-zero private key is not allowed'),
+                'Error message should indicate all-zero private key'
+            )
+        }
+        //PVT_R1_111111111111111111111111111111117FF8iA
+        keyStr = 'PVT_R1_' + Base58.encodeRipemd160Check(zeroBytes, 'R1');
+        try {
+            PrivateKey.from(keyStr)
+            assert.fail()
+        } catch (error) {
+            assert.ok(error instanceof Error, 'Error should be an instance of Error')
+            assert.ok(
+                error.message.includes('All-zero private key is not allowed'),
+                'Error message should indicate all-zero private key'
+            )
+        }
+    })
 })


### PR DESCRIPTION
 PVT_K1_111111111111111111111111111111112omJse
 PVT_R1_111111111111111111111111111111117FF8iA
 There will be the following exceptions：
 
 TypeError: Cannot read properties of null (reading 'fromRed')
      at Point.getX (node_modules/elliptic/lib/elliptic/curve/short.js:415:17)
      at Point._encode (node_modules/elliptic/lib/elliptic/curve/base.js:300:16)
      at Point.encode (node_modules/elliptic/lib/elliptic/curve/base.js:309:28)
      at Point.encodeCompressed (node_modules/elliptic/lib/elliptic/curve/base.js:295:15)
      at getPublic (src/crypto/get-public.ts:11:33)
      at PrivateKey.toPublic (src/chain/private-key.ts:128:28)
      at Context.<anonymous> (test/crypto.ts:217:14)
      at processImmediate (node:internal/timers:491:21)