### PR TITLE
Fix get compressed key bytes returned value

### DIFF
--- a/src/chain/public-key.ts
+++ b/src/chain/public-key.ts
@@ -73,7 +73,7 @@ export class PublicKey implements ABISerializableObject {
      * This is suitable for cryptographic operations like verification.
      */
     getCompressedKeyBytes(): Uint8Array {
-        return this.type === KeyType.WA ? this.data.array.subarray(0, 33) : this.data.array
+        return this.type === KeyType.WA ? this.data.array.slice(0, 33) : this.data.array
     }
 
     equals(other: PublicKeyType) {


### PR DESCRIPTION
The returned value should be a new array, instead of referencing the original one.